### PR TITLE
feat: UserRepository 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,7 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
+    testRuntimeOnly 'com.h2database:h2'
 }
 
 tasks.named('test') {

--- a/src/main/java/zip/ootd/ootdzip/user/User.java
+++ b/src/main/java/zip/ootd/ootdzip/user/User.java
@@ -7,16 +7,20 @@ import zip.ootd.ootdzip.BaseEntity;
 import java.time.LocalDate;
 
 @Entity
+@Table(name = "users")
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
 public class User extends BaseEntity {
 
+    @Column(nullable = false, unique = true)
     private String name;
 
     @Enumerated(EnumType.ORDINAL)
+    @Column(nullable = false)
     private UserGender gender = UserGender.UNKNOWN;
 
+    @Column(nullable = false)
     private LocalDate birthdate;
 
     private Integer height;
@@ -28,5 +32,6 @@ public class User extends BaseEntity {
     @Column(length = 2048)
     private String profileImage;
 
+    @Column(nullable = false)
     private Boolean isDeleted = false;
 }

--- a/src/main/java/zip/ootd/ootdzip/user/UserRepository.java
+++ b/src/main/java/zip/ootd/ootdzip/user/UserRepository.java
@@ -1,0 +1,7 @@
+package zip.ootd.ootdzip.user;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+}

--- a/src/test/java/zip/ootd/ootdzip/user/UserRepositoryTest.java
+++ b/src/test/java/zip/ootd/ootdzip/user/UserRepositoryTest.java
@@ -1,0 +1,48 @@
+package zip.ootd.ootdzip.user;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+public class UserRepositoryTest {
+
+    @Autowired private UserRepository userRepository;
+
+    @Test
+    @DisplayName("findAll이 작동해야 함")
+    void findAllUser() {
+        List<User> result = userRepository.findAll();
+        assertThat(result).isInstanceOf(List.class);
+    }
+
+    @Test
+    @DisplayName("user 정보 저장 및 불러오기 테스트")
+    void findUserById() {
+        String userName = "test user name";
+        UserGender gender = UserGender.MALE;
+        LocalDate birthdate =LocalDate.of(2000, 1, 1);
+        Integer userHeight = 180;
+        User saved = userRepository.save(new User(userName,
+                gender,
+                birthdate,
+                userHeight,
+                80,
+                true,
+                null,
+                false));
+
+        Optional<User> result = userRepository.findById(saved.getId());
+        assertThat(result).hasValueSatisfying((value) -> assertThat(value.getName()).isEqualTo(userName));
+        assertThat(result).hasValueSatisfying((value) -> assertThat(value.getGender()).isEqualTo(gender));
+        assertThat(result).hasValueSatisfying((value) -> assertThat(value.getBirthdate()).isEqualTo(birthdate));
+        assertThat(result).hasValueSatisfying((value) -> assertThat(value.getHeight()).isEqualTo(userHeight));
+    }
+}


### PR DESCRIPTION
사용자 필드에 nullable, unique 제한 추가.
테이블명을 엔티티명의 복수형으로 설정. (`user`는 테이블명으로 사용 불가)
테스트에 사용되는 H2 디펜던시 구성.